### PR TITLE
nexus9_demo: fix typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CFLAGS = \
 	-mlittle-endian \
 	-fno-stack-protector \
 	-mgeneral-regs-only \
-	-mstrict-align
+	-mstrict-align \
 	-fno-common \
 	-fno-builtin \
 	-ffreestanding \


### PR DESCRIPTION
Fix up a typo in the Makefile so it compiles. Cheers!
